### PR TITLE
Issues/4 shipping

### DIFF
--- a/assets/js/admin/wc-mnm-variable-mix-and-match-metabox.js
+++ b/assets/js/admin/wc-mnm-variable-mix-and-match-metabox.js
@@ -36,7 +36,7 @@ jQuery( function( $ ) {
 	} );
 
 	// Hide/Show variation dimension fields.
-	$( '#shipping_product_data' ).on( 'wc_mnm_packing_mode_changed', function( event, mode ) {
+	$( '#woocommerce-product-data' ).on( 'wc_mnm_packing_mode_changed', function( event, mode ) {
 
 		if ( 'undefined' === mode ) {
 			mode = event.target.value;

--- a/includes/class-wc-product-mix-and-match-variation.php
+++ b/includes/class-wc-product-mix-and-match-variation.php
@@ -139,6 +139,27 @@ class WC_Product_Mix_and_Match_Variation extends WC_Product_Variation {
 		return 'view' === $context ? apply_filters( $this->get_hook_prefix() . 'layout', $this->parent_data[ 'layout' ], $this ) : $this->parent_data[ 'layout' ];
 	}
 
+	/**
+	 * Packing Mode getter.
+	 *
+	 * @param  string $context
+	 * @return bool
+	 */
+	public function get_packing_mode( $context = 'view' ) {
+		return 'view' === $context ? apply_filters( $this->get_hook_prefix() . 'packing_mode', $this->parent_data[ 'packing_mode' ], $this ) : $this->parent_data[ 'packing_mode' ];
+		return $this->get_prop( 'packing_mode', $context );
+	}
+
+	/**
+	 * Shipping weight cumulative getter.
+	 *
+	 * @param  string $context
+	 * @return string
+	 */
+	public function get_weight_cumulative( $context = 'view' ) {
+		return 'view' === $context ? apply_filters( $this->get_hook_prefix() . 'weight_cumulative', $this->parent_data[ 'weight_cumulative' ], $this ) : $this->parent_data[ 'weight_cumulative' ];
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Setters.


### PR DESCRIPTION
Closes #4. `set_mnm_cart_item()` was failing for 2 reasons...

1. variations with shared contents had `read_child_items()` array keyed on DB item id. But then the `WC_MNM_Child_Item` was instantiated with props and NO id. This meant `get_child_item_id()` was returning `product-99` and so `$container->get_child_item()` would always fail to find the child item.

2. mnm variations did not inherit the packing methods from the parent